### PR TITLE
Add controller offset adjustments

### DIFF
--- a/HarmonyPatches/Patches/AdjustPlatformSpecificControllerTransformPatch.cs
+++ b/HarmonyPatches/Patches/AdjustPlatformSpecificControllerTransformPatch.cs
@@ -66,6 +66,7 @@ namespace SaberTailor.HarmonyPatches
                 {
                     transform.Translate(Configuration.Grip.PosLeft);
                     transform.Rotate(Configuration.Grip.RotLeft);
+                    transform.Translate(Configuration.Grip.OffsetLeft, Space.World);
                 }
                 return;
             }
@@ -80,6 +81,7 @@ namespace SaberTailor.HarmonyPatches
                 {
                     transform.Translate(Configuration.Grip.PosRight);
                     transform.Rotate(Configuration.Grip.RotRight);
+                    transform.Translate(Configuration.Grip.OffsetRight, Space.World);
                 }
                 return;
             }
@@ -98,6 +100,7 @@ namespace SaberTailor.HarmonyPatches
                     {
                         transform.Translate(Configuration.Grip.PosLeft);
                         transform.Rotate(Configuration.Grip.RotLeft);
+                        transform.Translate(Configuration.Grip.OffsetLeft, Space.World);
                     }
                     return;
                 }
@@ -112,6 +115,7 @@ namespace SaberTailor.HarmonyPatches
                     {
                         transform.Translate(Configuration.Grip.PosRight);
                         transform.Rotate(Configuration.Grip.RotRight);
+                        transform.Translate(Configuration.Grip.OffsetRight, Space.World);
                     }
                     return;
                 }

--- a/Settings/Classes/GripConfig.cs
+++ b/Settings/Classes/GripConfig.cs
@@ -13,5 +13,8 @@ namespace SaberTailor.Settings.Classes
 
         public Vector3 RotLeft;
         public Vector3 RotRight;
+
+        public Vector3 OffsetLeft;
+        public Vector3 OffsetRight;
     }
 }

--- a/Settings/Classes/GripRawConfig.cs
+++ b/Settings/Classes/GripRawConfig.cs
@@ -7,5 +7,8 @@
 
         public Int3 RotLeft;
         public Int3 RotRight;
+
+        public Int3 OffsetLeft;
+        public Int3 OffsetRight;
     }
 }

--- a/Settings/Configuration.cs
+++ b/Settings/Configuration.cs
@@ -267,9 +267,6 @@ namespace SaberTailor.Settings
             }
             #endregion
 
-            #region Controller offset
-            #endregion
-
             #region Menu settings
             if (cfgSection == ConfigSection.All || cfgSection == ConfigSection.Menu)
             {

--- a/Settings/Configuration.cs
+++ b/Settings/Configuration.cs
@@ -91,6 +91,7 @@ namespace SaberTailor.Settings
             UpdateSaberLength();
             UpdateSaberPosition();
             UpdateSaberRotation();
+            UpdateSaberOffset();
         }
 
         /// <summary>
@@ -109,6 +110,15 @@ namespace SaberTailor.Settings
         {
             Grip.PosLeft = Int3.ToVector3(GripCfg.PosLeft) / 1000f;
             Grip.PosRight = Int3.ToVector3(GripCfg.PosRight) / 1000f;
+        }
+
+        /// <summary>
+        /// Update Saber Offset
+        /// </summary>
+        internal static void UpdateSaberOffset()
+        {
+            Grip.OffsetLeft = Int3.ToVector3(GripCfg.OffsetLeft) / 1000f;
+            Grip.OffsetRight = Int3.ToVector3(GripCfg.OffsetRight) / 1000f;
         }
 
         /// <summary>
@@ -140,6 +150,7 @@ namespace SaberTailor.Settings
                     y = -GripCfg.RotRight.y,
                     z = GripCfg.RotRight.z
                 };
+                GripCfg.OffsetLeft = new Int3(GripCfg.OffsetRight);
             }
             else
             {
@@ -155,6 +166,7 @@ namespace SaberTailor.Settings
                     y = -GripCfg.RotLeft.y,
                     z = GripCfg.RotLeft.z
                 };
+                GripCfg.OffsetRight = new Int3(GripCfg.OffsetLeft);
             }
         }
 
@@ -215,6 +227,14 @@ namespace SaberTailor.Settings
 
                 Int3 gripLeftRotation = PluginConfig.Instance.GripLeftRotation ?? Int3.zero;
                 GripCfg.RotLeft = new Int3(gripLeftRotation);
+
+                Int3 gripLeftOffset = PluginConfig.Instance.GripLeftOffset ?? Int3.zero;
+                GripCfg.OffsetLeft = new Int3()
+                {
+                    x = Mathf.Clamp(gripLeftOffset.x, -500, 500),
+                    y = Mathf.Clamp(gripLeftOffset.y, -500, 500),
+                    z = Mathf.Clamp(gripLeftOffset.z, -500, 500)
+                };
             }
 
             if (cfgSection == ConfigSection.All || cfgSection == ConfigSection.Grip || cfgSection == ConfigSection.GripRight)
@@ -229,6 +249,14 @@ namespace SaberTailor.Settings
 
                 Int3 gripRightRotation = PluginConfig.Instance.GripRightRotation ?? Int3.zero;
                 GripCfg.RotRight = new Int3(gripRightRotation);
+
+                Int3 gripRightOffset = PluginConfig.Instance.GripRightOffset ?? Int3.zero;
+                GripCfg.OffsetRight = new Int3()
+                {
+                    x = Mathf.Clamp(gripRightOffset.x, -500, 500),
+                    y = Mathf.Clamp(gripRightOffset.y, -500, 500),
+                    z = Mathf.Clamp(gripRightOffset.z, -500, 500)
+                };
             }
 
             if (cfgSection == ConfigSection.All || cfgSection == ConfigSection.Grip)
@@ -237,6 +265,9 @@ namespace SaberTailor.Settings
                 Grip.ModifyMenuHiltGrip = PluginConfig.Instance.ModifyMenuHiltGrip;
                 Grip.UseBaseGameAdjustmentMode = PluginConfig.Instance.UseBaseGameAdjustmentMode;
             }
+            #endregion
+
+            #region Controller offset
             #endregion
 
             #region Menu settings
@@ -288,6 +319,9 @@ namespace SaberTailor.Settings
             // Even though the field says GripLeftRotation/GripRightRotation, it is actually the Cfg values that are stored!
             config.GripLeftRotation = new Int3(GripCfg.RotLeft);
             config.GripRightRotation = new Int3(GripCfg.RotRight);
+
+            PluginConfig.Instance.GripLeftOffset = new Int3(GripCfg.OffsetLeft);
+            PluginConfig.Instance.GripRightOffset = new Int3(GripCfg.OffsetRight);
 
             config.IsGripModEnabled = Grip.IsGripModEnabled;
             config.ModifyMenuHiltGrip = Grip.ModifyMenuHiltGrip;

--- a/Settings/UI/MainSettings.cs
+++ b/Settings/UI/MainSettings.cs
@@ -177,6 +177,42 @@ namespace SaberTailor.Settings.UI
                 RefreshRotationSettings();
             }
         }
+
+        [UIValue("saber-left-offset-x")]
+        public int GripLeftOffsetX
+        {
+            get => Configuration.GripCfg.OffsetLeft.x;
+            set
+            {
+                int newVal = Increment(Configuration.GripCfg.OffsetLeft.x, Configuration.Menu.SaberPosIncrement, value);
+                Configuration.GripCfg.OffsetLeft.x = Mathf.Clamp(newVal, SaberPosMin, SaberPosMax);
+                RefreshOffsetSettings();
+            }
+        }
+
+        [UIValue("saber-left-offset-y")]
+        public int GripLeftOffsetY
+        {
+            get => Configuration.GripCfg.OffsetLeft.y;
+            set
+            {
+                int newVal = Increment(Configuration.GripCfg.OffsetLeft.y, Configuration.Menu.SaberPosIncrement, value);
+                Configuration.GripCfg.OffsetLeft.z = Mathf.Clamp(newVal, SaberPosMin, SaberPosMax);
+                RefreshOffsetSettings();
+            }
+        }
+
+        [UIValue("saber-left-offset-z")]
+        public int GripLeftOffsetZ
+        {
+            get => Configuration.GripCfg.OffsetLeft.z;
+            set
+            {
+                int newVal = Increment(Configuration.GripCfg.OffsetLeft.y, Configuration.Menu.SaberPosIncrement, value);
+                Configuration.GripCfg.OffsetLeft.z = Mathf.Clamp(newVal, SaberPosMin, SaberPosMax);
+                RefreshOffsetSettings();
+            }
+        }
         #endregion
 
         #region Saber Grip Right
@@ -249,6 +285,42 @@ namespace SaberTailor.Settings.UI
                 int newVal = Increment(Configuration.GripCfg.RotRight.z, SaberRotIncrement, value);
                 Configuration.GripCfg.RotRight.z = Mathf.Clamp(newVal, SaberRotMin, SaberRotMax);
                 RefreshRotationSettings();
+            }
+        }
+
+        [UIValue("saber-right-offset-x")]
+        public int GripRightOffsetX
+        {
+            get => Configuration.GripCfg.OffsetRight.x;
+            set
+            {
+                int newVal = Increment(Configuration.GripCfg.OffsetRight.x, Configuration.Menu.SaberPosIncrement, value);
+                Configuration.GripCfg.OffsetRight.x = Mathf.Clamp(newVal, SaberPosMin, SaberPosMax);
+                RefreshOffsetSettings();
+            }
+        }
+
+        [UIValue("saber-right-offset-y")]
+        public int GripRightOffsetY
+        {
+            get => Configuration.GripCfg.OffsetRight.y;
+            set
+            {
+                int newVal = Increment(Configuration.GripCfg.OffsetRight.y, Configuration.Menu.SaberPosIncrement, value);
+                Configuration.GripCfg.OffsetRight.z = Mathf.Clamp(newVal, SaberPosMin, SaberPosMax);
+                RefreshOffsetSettings();
+            }
+        }
+
+        [UIValue("saber-right-offset-z")]
+        public int GripRightOffsetZ
+        {
+            get => Configuration.GripCfg.OffsetRight.z;
+            set
+            {
+                int newVal = Increment(Configuration.GripCfg.OffsetRight.y, Configuration.Menu.SaberPosIncrement, value);
+                Configuration.GripCfg.OffsetRight.z = Mathf.Clamp(newVal, SaberPosMin, SaberPosMax);
+                RefreshOffsetSettings();
             }
         }
         #endregion
@@ -482,6 +554,14 @@ namespace SaberTailor.Settings.UI
             Configuration.UpdateSaberPosition();
         }
 
+        [UIAction("update-saber-offset")]
+        public async void OnUpdateSaberOffset(float _)
+        {
+            // Delay this UI event to allow UI value to be set first
+            await Task.Delay(20);
+            Configuration.UpdateSaberOffset();
+        }
+
         [UIAction("#apply")]
         public void OnApply() => StoreConfiguration();
 
@@ -554,6 +634,7 @@ namespace SaberTailor.Settings.UI
             RefreshModSettingsUI();
             Configuration.UpdateSaberPosition();
             Configuration.UpdateSaberRotation();
+            Configuration.UpdateSaberOffset();
         }
 
         /// <summary>
@@ -589,6 +670,14 @@ namespace SaberTailor.Settings.UI
         private void RefreshRotationSettings()
         {
             parserParams.EmitEvent("refresh-sabertailor-rotation-values");
+        }
+
+        /// <summary>
+        /// Refresh offset settings UI
+        /// </summary>
+        private void RefreshOffsetSettings()
+        {
+            parserParams.EmitEvent("refresh-sabertailor-offset-values");
         }
 
         private void ImportGripFromGameSettings()

--- a/Settings/UI/Views/mainsettings.bsml
+++ b/Settings/UI/Views/mainsettings.bsml
@@ -77,7 +77,7 @@
 
       <!--Saber Grip Right-->
       <settings-submenu text='&#62; Right Saber Settings...' hover-hint='Adjust position and rotation of the right saber.'>
-          <scrollable-settings-container>
+        <scrollable-settings-container>
           <increment-setting text='Pos X (Left/Right)' value='saber-right-position-x'
                              apply-on-change='true' on-change='update-saber-position' get-event="refresh-sabertailor-position-values"
                              integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'

--- a/Settings/UI/Views/mainsettings.bsml
+++ b/Settings/UI/Views/mainsettings.bsml
@@ -21,7 +21,7 @@
 
       <!--Saber Grip Left-->
       <settings-submenu text='&#62; Left Saber Settings...' hover-hint='Adjust position and rotation of the left saber.'>
-        <settings-container>
+        <scrollable-settings-container>
           <increment-setting text='Pos X (Left/Right)' value='saber-left-position-x'
                              apply-on-change='true' on-change='update-saber-position' get-event="refresh-sabertailor-position-values"
                              integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
@@ -51,18 +51,33 @@
                              apply-on-change='true' on-change='update-saber-rotation' get-event="refresh-sabertailor-rotation-values"
                              integer-only='true' min='~saber-rot-min' max='~saber-rot-max' increment='1'
                              formatter='rotation-formatter' hover-hint='Rotates the saber around its own axis.' />
+            
+          <increment-setting text='Pos X (Left/Right)' value='saber-left-offset-x'
+                             apply-on-change='true' on-change='update-saber-offset' get-event="refresh-sabertailor-offset-values"
+                             integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
+                             formatter='position-formatter' hover-hint='Moves the controller left/right.' />
+
+          <increment-setting text='Pos Y (Down/Up)' value='saber-left-offset-y'
+                             apply-on-change='true' on-change='update-saber-offset' get-event="refresh-sabertailor-offset-values"
+                             integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
+                             formatter='position-formatter' hover-hint='Moves the controller down/up.' />
+
+          <increment-setting text='Pos Z (Bwd./Fwd.)' value='saber-left-offset-z'
+                             apply-on-change='true' on-change='update-saber-offset' get-event="refresh-sabertailor-offset-values"
+                             integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
+                             formatter='position-formatter' hover-hint='Moves the controller backwards/forwards.' />
 
           <horizontal>
             <clickable-text text='&#60; Back' align='Left' click-event='back' />
             <clickable-text text='Mirror to Right' align='Midline' click-event='mirror-grip-left-to-right' />
             <clickable-text text='Revert' align='Right' click-event='reset-saber-config-grip-left' />
           </horizontal>
-        </settings-container>
+        </scrollable-settings-container>
       </settings-submenu>
 
       <!--Saber Grip Right-->
       <settings-submenu text='&#62; Right Saber Settings...' hover-hint='Adjust position and rotation of the right saber.'>
-        <settings-container>
+          <scrollable-settings-container>
           <increment-setting text='Pos X (Left/Right)' value='saber-right-position-x'
                              apply-on-change='true' on-change='update-saber-position' get-event="refresh-sabertailor-position-values"
                              integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
@@ -92,13 +107,28 @@
                              apply-on-change='true' on-change='update-saber-rotation' get-event="refresh-sabertailor-rotation-values"
                              integer-only='true' min='~saber-rot-min' max='~saber-rot-max' increment='1'
                              formatter='rotation-formatter' hover-hint='Rotates the saber around its own axis.' />
+          
+          <increment-setting text='Pos X (Left/Right)' value='saber-right-offset-x'
+                             apply-on-change='true' on-change='update-saber-offset' get-event="refresh-sabertailor-offset-values"
+                             integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
+                             formatter='position-formatter' hover-hint='Moves the controller left/right.' />
+
+          <increment-setting text='Pos Y (Down/Up)' value='saber-right-offset-y'
+                             apply-on-change='true' on-change='update-saber-offset' get-event="refresh-sabertailor-offset-values"
+                             integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
+                             formatter='position-formatter' hover-hint='Moves the controller down/up.' />
+
+          <increment-setting text='Pos Z (Bwd./Fwd.)' value='saber-right-offset-z'
+                             apply-on-change='true' on-change='update-saber-offset' get-event="refresh-sabertailor-offset-values"
+                             integer-only='true' min='~saber-pos-min' max='~saber-pos-max' increment='1'
+                             formatter='position-formatter' hover-hint='Moves the controller backwards/forwards.' />
 
           <horizontal>
             <clickable-text text='&#60; Back' align='Left' click-event='back' />
             <clickable-text text='Mirror to Left' align='Midline' click-event='mirror-grip-right-to-left' />
             <clickable-text text='Revert' align='Right' click-event='reset-saber-config-grip-right' />
           </horizontal>
-        </settings-container>
+        </scrollable-settings-container>
       </settings-submenu>
 
       <!--Saber Grip Precision Settings-->

--- a/Settings/Utilities/PluginConfig.cs
+++ b/Settings/Utilities/PluginConfig.cs
@@ -27,6 +27,9 @@ namespace SaberTailor.Settings.Utilities
         public Int3 GripLeftRotation = new Int3();      // Rotation in °
         public Int3 GripRightRotation = new Int3();
 
+        public Int3 GripLeftOffset = new Int3();        // Offset in mm
+        public Int3 GripRightOffset = new Int3();
+
         public bool ModifyMenuHiltGrip = true;
         public bool UseBaseGameAdjustmentMode = true;
 

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,16 @@ The default values are below:
     "y": 0,
     "z": 0
   },
+  "GripLeftOffset": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "GripRightOffset": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
   "ModifyMenuHiltGrip": true,
   "UseBaseGameAdjustmentMode": false,
   "SaberPosIncrement": 10,
@@ -179,6 +189,19 @@ Alters the position of the left/right saber, relative to the default location. Y
 - `+z` rolls the saber counter-clockwise around its own axis, EG: `30` rotates the saber 30 degrees counter-clockwise. (This is only useful if you have custom sabers that are not cylindrical shaped and you want to correct for a different grip (e.g. Vive B-Grip)
 
 Alters the rotation of the sabers. The center of rotation is where the saber's hit-box starts, which is just after the glowing line on the handle.
+
+### Grip Offset (Left + Right)
+
+- **Setting**: `GripLeftOffset`, `GripRightOffset`
+- **Unit**: Millimeters
+- **Default**: `"x": 0, "y": 0, "z": 0`
+- **Maximum**: `500` on any axis
+
+- `+x` moves the controller right, EG: `200` moves the controller 20 centimeters right.
+- `+y` moves the controller up, EG: `100` moves the controller 10 centimeters up.
+- `+z` moves the controller forward, EG: `300` moves the controller 30 centimeters forward.
+
+Will simulate moving your physical controller location in case of drifts in the default position. You cannot move the controller more than 50 centimeters away on any axis!
 
 ### Menu hilt adjustments
 


### PR DESCRIPTION
Applies the normal SaberTailor adjustments and then moves everything according to the controller offset, in case your controllers are not being reported in the correct location in your default standing location.

Currently the patch set is for version 2.9.0. I'll update this later to target 3.0.3 if there are any additional changes that need to be made.

Menus could use some adjustments, I let it scroll because I was lazy.

There is no need to change the config version, the config loader will automatically detect that there is no offset and apply a default of 0.